### PR TITLE
Add functionality to post a comment 

### DIFF
--- a/manifoldpy/api.py
+++ b/manifoldpy/api.py
@@ -38,6 +38,8 @@ SINGLE_MARKET_URL = V0_URL + "market/{}"
 USERNAME_URL = V0_URL + "user/{}"
 USER_ID_URL = V0_URL + "user/by-id/{}"
 USERS_URL = V0_URL + "users"
+COMMENT_URL = V0_URL + "comment"
+
 
 # POST URLs
 MAKE_BET_URL = V0_URL + "bet"
@@ -1111,6 +1113,34 @@ class APIWrapper:
         """
         prepped = self._prep_sell(market_id, outcome, shares=shares)
         return requests.Session().send(prepped)
+    
+    def _prep_make_comment(
+        self,
+        contractId: str,
+        content: str, #The comment to post, formatted as Markdown,
+    ) -> requests.PreparedRequest:
+        """Prepare a comment POST request.
+        See `make_comment` for details.
+        """
+        data = {"contractId": contractId, "markdown": content}
+        req = requests.Request("POST", MAKE_COMMENT_URL, headers=self.headers, json=data)
+        return req.prepare()
+
+    def make_comment(
+        self,
+        contractId: str,
+        content: str, #The comment to post, formatted as Markdown,
+    ) -> requests.Response:
+        """Post a comment.
+        [API reference](https://docs.manifold.markets/api#post-v0comment)
+
+        Args:
+            contractId: The market id.
+            content: The comment to post, formatted as a markdown string.
+        """
+        prepped = self._prep_make_comment(contractId, content)
+        return requests.Session().send(prepped)
+
 
 
 def use_api(f):

--- a/manifoldpy/api.py
+++ b/manifoldpy/api.py
@@ -38,7 +38,6 @@ SINGLE_MARKET_URL = V0_URL + "market/{}"
 USERNAME_URL = V0_URL + "user/{}"
 USER_ID_URL = V0_URL + "user/by-id/{}"
 USERS_URL = V0_URL + "users"
-COMMENT_URL = V0_URL + "comment"
 
 
 # POST URLs
@@ -49,6 +48,8 @@ ADD_LIQUIDITY_URL = V0_URL + "market/{}/add-liquidity"
 CLOSE_URL = V0_URL + "market/{}/close"
 RESOLVE_MARKET_URL = V0_URL + "market/{}/resolve"
 SELL_SHARES_URL = V0_URL + "market/{}/sell"
+MAKE_COMMENT_URL = V0_URL + "comment"
+
 
 MarketT = TypeVar("MarketT", bound="Market")
 OutcomeType = Literal[

--- a/tests/api_test/prep_test.py
+++ b/tests/api_test/prep_test.py
@@ -92,11 +92,15 @@ def test_sell_prepared(wrapper):
 
     assert prepped.body == b'{"outcome": "YES", "shares": 5}'
 
-def test_post_comment(wrapper):
-    prepped = wrapper._prep_make_comment("1", 5)
+
+def test_comment_prepared(wrapper):
+    prepped = wrapper._prep_make_comment("1", "Comment")
     assert prepped.headers == {
-    "Content-Type": "application/json",
-    "Authorization": "Key no_key",
-    "Content-Length": "31",
+        "Content-Type": "application/json",
+        "Authorization": "Key no_key",
+        "Content-Length": "42",
     }
+
+    assert prepped.body == b'{"contractId": "1", "markdown": "Comment"}'
+
 

--- a/tests/api_test/prep_test.py
+++ b/tests/api_test/prep_test.py
@@ -91,3 +91,12 @@ def test_sell_prepared(wrapper):
     }
 
     assert prepped.body == b'{"outcome": "YES", "shares": 5}'
+
+def test_post_comment(wrapper):
+    prepped = wrapper._prep_make_comment("1", 5)
+    assert prepped.headers == {
+    "Content-Type": "application/json",
+    "Authorization": "Key no_key",
+    "Content-Length": "31",
+    }
+


### PR DESCRIPTION
This PR
- adds a method to the APIWrapper class to create a comment (at this time, I only implemented markdown-formatted strings), [API Reference](https://docs.manifold.markets/api#post-v0comment)
- adds a test

Would be very happy for this to be merged. I already used this and had no problem. If there is any additional questions, I'd be happy to answer. 