### PR TITLE
`manifold.markets/api/v0` -> `api.manifold.markets/v0`

### DIFF
--- a/manifoldpy/api.py
+++ b/manifoldpy/api.py
@@ -11,7 +11,7 @@ from attr import define, field
 
 from manifoldpy import config
 
-V0_URL = "https://manifold.markets/api/v0/"
+V0_URL = "https://api.manifold.markets/v0/"
 
 # GET URLs
 


### PR DESCRIPTION
The new one is better; the old one is gonna go away.